### PR TITLE
Fix for bug where >12 and < 50 vehicles would error

### DIFF
--- a/src/libs/http.py
+++ b/src/libs/http.py
@@ -95,6 +95,8 @@ class AsyncHTTPClient:
         # If the length of the results list is 1, this is likely the results of a single
         # HTTP request. So returning just that one result, not a list containing one item.
         # If the length is > 1, return the list containing the httpx.Responses.
+        # TODO: Return all results as a list. Will need to refactor all manufacturer
+        # routers.
         if len(results) == 1:
             return results[0]
         else:

--- a/src/routers/ford.py
+++ b/src/routers/ford.py
@@ -160,6 +160,13 @@ async def main(
 
         remainder = await http.get(uri=urls_to_fetch)
 
+        # If we only have the initial API call and one additional API call, the response
+        # back from the http helper library is a httpx.Response object. If we have multiple
+        # additional API calls, the response back is a list. Catching this situation and
+        # throwing that single httpx.Response object into a list for further processing.
+        if type(remainder) != list:
+            remainder = [remainder]
+
         # Loop through the inventory results list
         for api_result in remainder:
             result = api_result.json()


### PR DESCRIPTION
In a situation where a given inventory search would result in > 12 and < 50 vehicles found, this API would throw an Exception and 500 back to the client.